### PR TITLE
pistachio_marduk_ca8210.dts: reduce spi-max-frequency to 3MHz

### DIFF
--- a/target/linux/pistachio/dts/pistachio_marduk_ca8210.dts
+++ b/target/linux/pistachio/dts/pistachio_marduk_ca8210.dts
@@ -35,7 +35,7 @@
 		status = "okay";
 		compatible = "cascoda,ca8210";
 		reg = <0>;
-		spi-max-frequency = <4000000>;
+		spi-max-frequency = <3000000>;
 		spi-cpol;
 		reset-gpio = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		irq-gpio = <&gpio2 12 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
to be on safer side,since ca8210 supports max 4MHz.

Signed-off-by: Abhijit Mahajani <Abhijit.Mahajani@imgtec.com>