### PR TITLE
Define gpio range for each bank in pin controller

### DIFF
--- a/target/linux/pistachio/dts/pistachio.dtsi
+++ b/target/linux/pistachio/dts/pistachio.dtsi
@@ -462,6 +462,7 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+			gpio-ranges = <&pinctrl 0 0 16>;
 
 			interrupt-controller;
 			#interrupt-cells = <2>;
@@ -472,6 +473,7 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+			gpio-ranges = <&pinctrl 0 16 16>;
 
 			interrupt-controller;
 			#interrupt-cells = <2>;
@@ -482,6 +484,7 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+			gpio-ranges = <&pinctrl 0 32 16>;
 
 			interrupt-controller;
 			#interrupt-cells = <2>;
@@ -492,6 +495,7 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+			gpio-ranges = <&pinctrl 0 48 16>;
 
 			interrupt-controller;
 			#interrupt-cells = <2>;
@@ -502,6 +506,7 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+			gpio-ranges = <&pinctrl 0 64 16>;
 
 			interrupt-controller;
 			#interrupt-cells = <2>;
@@ -512,6 +517,7 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+			gpio-ranges = <&pinctrl 0 80 10>;
 
 			interrupt-controller;
 			#interrupt-cells = <2>;


### PR DESCRIPTION
GPIO hogs can only be used if the range of each bank is defined,
which is needed for enabling the audio amplifier at boot.

Signed-off-by: Francois Berder <Francois.Berder@imgtec.com>