### PR TITLE
Avoid building DTB in image builder

### DIFF
--- a/target/linux/pistachio/image/Makefile
+++ b/target/linux/pistachio/image/Makefile
@@ -87,7 +87,7 @@ endif
 endef
 
 define Image/BuildKernel
-	$(call MkDTB,$($(PROFILE)_DEVICE_DTS))
+	$(if $(IB),,$(call MkDTB,$($(PROFILE)_DEVICE_DTS)))
 	$(call Image/BuildKernel/uImage,$(PROFILE))
 endef
 


### PR DESCRIPTION
Image builder failed to build DTB because it was trying to
compile the dts although the compiler was not available and
the DTB was already built.

The solution checks if the IB variable is present and if not,
builds the dtb.

Signed-off-by: Francois Berder <Francois.Berder@imgtec.com>