### PR TITLE
pistachio: enable kmod-mac802154 instead of kmod-ieee802154

### DIFF
--- a/target/linux/pistachio/marduk/target.mk
+++ b/target/linux/pistachio/marduk/target.mk
@@ -12,7 +12,7 @@ DEFAULT_PACKAGES+=kmod-leds-gpio kmod-ledtrig-heartbeat kmod-i2c-core i2c-tools 
                   kmod-uccp420wlan kmod-cfg80211 fping iw hostapd wpa-cli wpa-supplicant \
                   kmod-tpm-i2c-infineon kmod-random-tpm tpm-tools \
                   uhttpd uboot-envtools tcpdump board-test proddata \
-                  luci kmod-bluetooth kmod-ieee802154
+                  luci kmod-bluetooth kmod-mac802154
 
 define Profile/marduk/default
 	$(1)_DEVICE_DTS:=$(2)


### PR DESCRIPTION
kmod-mac802154 is dependent on kmod-iee8052154.

Signed-off-by: Abhijit Mahajani Abhijit.Mahajani@imgtec.com
