### PR TITLE
Jenkinsfile: discard old builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ for (feed in customFeeds) {
 }
 
 properties([
+    buildDiscarder(logRotator(numToKeepStr: '5')),
     parameters([
         booleanParam(defaultValue: false, description: 'Clean out everything.', \
             name: 'FULL_CLEAN'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,9 @@
  *
  * Configure as needed, pull in the feeds and run the build. Allows
  * overridding feeds listed using build parameters.
+ * 
+ * Note this script needs some extra Jenkins permissions to be
+ * approved.
  */
 // TODO be careful with using dir() until JENKINS-33510 is fixed
 
@@ -22,6 +25,8 @@ for (feed in customFeeds) {
 properties([
     buildDiscarder(logRotator(numToKeepStr: '5')),
     parameters([
+        booleanParam(defaultValue: false, description: 'Build extra tools such as toolchain, \
+            SDK and Image builder', name: 'BUILD_TOOLS'),
         booleanParam(defaultValue: false, description: 'Build *all* packages for opkg. Warning \
             this will take a very long time!', name: 'ALL_PACKAGES'),
         stringParam(defaultValue: 'target/linux/pistachio/creator-platform-default-cascoda.config', \
@@ -33,86 +38,105 @@ properties([
 
 node('docker && imgtec') {  // Only run on internal slaves as build takes a lot of resources
     def docker_image
-    stage('Prepare') {
-        checkout scm
 
-        // Default config
-        sh "cp ${env.DEFCONFIG_FILE} .config"
-
-        // Versioning
-        sh "sed -i 's/.*CONFIG_VERSION_NUMBER.*/CONFIG_VERSION_NUMBER=\"${env.VERSION?.trim() ?: 'j' + env.BUILD_NUMBER}\"/g' .config"
-        sh 'scripts/getver.sh > version'
-
-        echo 'Enabling toolchain, image builder and sdk creation'
-        sh 'echo \'' \
-         + 'CONFIG_MAKE_TOOLCHAIN=y\n' \
-         + 'CONFIG_IB=y\n' \
-         + 'CONFIG_SDK=y\n' \
-         + '\' >> .config'
-
-        // Build all (for opkg)
-        // TODO grab vault creds and mod config to use OPKGSMIME
-        if (env.ALL_PACKAGES == 'true'){  // TODO seems like a bug that bool is a string
-            echo 'Enabling all user and kernel packages'
-            sh 'echo \'' \
-             + 'CONFIG_ALL=y\n' \
-             + 'CONFIG_ALL_KMODS=y\n' \
-             + '\' >> .config'
-        }
-
-        // Boardfarm-able
-        // TODO work out which ones we actually have
-        echo 'Enabling usb ethernet adapters modules (for boardfarm testing)'
-        sh 'echo \'' \
-         + 'CONFIG_PACKAGE_kmod-usb-net=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-asix=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-cdc-eem=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-cdc-ether=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-cdc-mbim=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-cdc-ncm=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-cdc-subset=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-dm9601-ether=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-hso=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-huawei-cdc-ncm=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-ipheth=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-kalmia=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-kaweth=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-mcs7830=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-pegasus=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-qmi-wwa=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-rndis=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-rtl8150=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-rtl8152=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-sierrawireless=y\n' \
-         + 'CONFIG_PACKAGE_kmod-usb-net-smsc95xx=y\n' \
-         + '\' >> .config'
-
-        // If specified override each feed with local clone
-        for (feed in customFeeds) {
-            if (env."OVERRIDE_${feed[1].toUpperCase()}"?.trim()){
-                dir("feed-${feed[1]}") {
-                    checkout([
-                        $class: 'GitSCM',
-                        branches: [[name: env."OVERRIDE_${feed[1].toUpperCase()}"]],
-                        userRemoteConfigs: [[
-                            refspec: '+refs/pull/*/head:refs/remotes/origin/PR-* \
-                                +refs/heads/*:refs/remotes/origin/*',
-                            url: "${feed[2]}/${feed[1]}.git"
-                        ]]
-                    ])
-                }
-                // Replace (or add if not exists) feed with local clone
-                sh "grep -q 'src-.* ${feed[0]} .*' feeds.conf.default && \
-                    sed -i 's|^.*\\s\\(${feed[0]}\\)\\s.*\$|src-link \\1 ../feed-${feed[1]}|g' feeds.conf.default || \
-                    echo 'src-link ${feed[0]} ../feed-${feed[1]}' >> feeds.conf.default"
-            }
-        }
-        sh 'cat .config'
-        sh 'cat feeds.conf.default'
+    stage('Prepare Docker container') {
+        // Setup a local docker container to run build on this slave
         docker_image = docker.image "imgtec/creator-builder:latest" // TODO for now have manually setup on slave
     }
-    docker_image.inside {
+
+    docker_image.inside("-v ${WORKSPACE}/../../reference-repos:${WORKSPACE}/../../reference-repos:ro") {
         stage('Configure') {
+            // Checkout a clean version of the repo using reference repo to save bandwidth/time
+            checkout([$class: 'GitSCM',
+                userRemoteConfigs: scm.userRemoteConfigs,
+                branches: scm.branches,
+                doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
+                submoduleCfg: scm.submoduleCfg,
+                browser: scm.browser,
+                gitTool: scm.gitTool,
+                extensions: scm.extensions + [
+                    [$class: 'CleanCheckout'],
+                    [$class: 'PruneStaleBranch'],
+                    [$class: 'CloneOption', honorRefspec: true, reference: "${WORKSPACE}/../../reference-repos/openwrt.git"],
+                ],
+            ])
+
+            // Default config
+            sh "cp ${env.DEFCONFIG_FILE} .config"
+
+            // Versioning
+            sh "sed -i 's/.*CONFIG_VERSION_NUMBER.*/CONFIG_VERSION_NUMBER=\"${env.VERSION?.trim() ?: 'j' + env.BUILD_NUMBER}\"/g' .config"
+            sh 'scripts/getver.sh > version'
+
+            // Build tools
+            if (env.BUILD_TOOLS == 'true') {
+                echo 'Enabling toolchain, image builder and sdk creation'
+                sh 'echo \'' \
+                 + 'CONFIG_MAKE_TOOLCHAIN=y\n' \
+                 + 'CONFIG_IB=y\n' \
+                 + 'CONFIG_SDK=y\n' \
+                 + '\' >> .config'
+            }
+
+            // Build all (for opkg)
+            // TODO grab vault creds and mod config to use OPKGSMIME
+            if (env.ALL_PACKAGES == 'true'){  // TODO seems like a bug that bool is a string
+                echo 'Enabling all user and kernel packages'
+                sh 'echo \'' \
+                 + 'CONFIG_ALL=y\n' \
+                 + 'CONFIG_ALL_KMODS=y\n' \
+                 + '\' >> .config'
+            }
+
+            // Boardfarm-able
+            // TODO work out which ones we actually have
+            echo 'Enabling usb ethernet adapters modules (for boardfarm testing)'
+            sh 'echo \'' \
+             + 'CONFIG_PACKAGE_kmod-usb-net=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-asix=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-cdc-eem=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-cdc-ether=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-cdc-mbim=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-cdc-ncm=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-cdc-subset=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-dm9601-ether=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-hso=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-huawei-cdc-ncm=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-ipheth=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-kalmia=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-kaweth=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-mcs7830=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-pegasus=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-qmi-wwa=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-rndis=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-rtl8150=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-rtl8152=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-sierrawireless=y\n' \
+             + 'CONFIG_PACKAGE_kmod-usb-net-smsc95xx=y\n' \
+             + '\' >> .config'
+
+            // If specified override each feed with local clone
+            for (feed in customFeeds) {
+                if (env."OVERRIDE_${feed[1].toUpperCase()}"?.trim()){
+                    dir("feed-${feed[1]}") {
+                        checkout([
+                            $class: 'GitSCM',
+                            branches: [[name: env."OVERRIDE_${feed[1].toUpperCase()}"]],
+                            userRemoteConfigs: [[
+                                refspec: '+refs/pull/*/head:refs/remotes/origin/PR-* \
+                                    +refs/heads/*:refs/remotes/origin/*',
+                                url: "${feed[2]}/${feed[1]}.git"
+                            ]]
+                        ])
+                    }
+                    // Replace (or add if not exists) feed with local clone
+                    sh "grep -q 'src-.* ${feed[0]} .*' feeds.conf.default && \
+                        sed -i 's|^.*\\s\\(${feed[0]}\\)\\s.*\$|src-link \\1 ../feed-${feed[1]}|g' feeds.conf.default || \
+                        echo 'src-link ${feed[0]} ../feed-${feed[1]}' >> feeds.conf.default"
+                }
+            }
+            sh 'cat .config'
+            sh 'cat feeds.conf.default'
             sh 'scripts/feeds update -a && scripts/feeds install -a'
             sh 'make defconfig'
         }


### PR DESCRIPTION
Master was running out of space so only keep the latest 5 builds (per branch) - all PR builds are deleted once merged

Slaves were also running out of space due to there being so many PR branches therefore wipe workspaces when builds are finished (this causes the problem of having to do full clones everytime so also add local reference repo).

Signed-off-by: Ian Pozella <Ian.Pozella@imgtec.com>