### PR TITLE
Opkg signing

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -12,7 +12,7 @@ __target_inc=1
 DEVICE_TYPE?=router
 
 # Default packages - the really basic set
-DEFAULT_PACKAGES:=base-files libc libgcc busybox dropbear mtd uci opkg-smime netifd fstools uclient-fetch logd
+DEFAULT_PACKAGES:=base-files libc libgcc busybox dropbear mtd uci opkg netifd fstools uclient-fetch logd
 # For nas targets
 DEFAULT_PACKAGES.nas:=block-mount fdisk lsblk mdadm
 # For router targets

--- a/target/linux/pistachio/creator-platform-default-cascoda.config
+++ b/target/linux/pistachio/creator-platform-default-cascoda.config
@@ -2,21 +2,9 @@ CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_ca8210=y
 CONFIG_IMAGEOPT=y
-CONFIG_LIBCURL_OPENSSL=y
-CONFIG_OPENSSL_WITH_EC=y
-CONFIG_PACKAGE_ca-certificates=y
-CONFIG_PACKAGE_curl=y
-CONFIG_PACKAGE_libcurl=y
-CONFIG_PACKAGE_libopenssl=y
-CONFIG_PACKAGE_libustream-openssl=y
-# CONFIG_PACKAGE_opkg is not set
-CONFIG_PACKAGE_opkg-smime=y
-# CONFIG_PACKAGE_usign is not set
-CONFIG_PACKAGE_zlib=y
-# CONFIG_SIGNED_PACKAGES is not set
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_NICK="Ci40"
-CONFIG_VERSION_REPO="https://downloads.creatordev.io/pistachio/marduk/packages"
+CONFIG_VERSION_REPO="http://downloads.creatordev.io/pistachio/marduk/packages"
 CONFIG_VERSION_MANUFACTURER="Imagination Technologies"
 CONFIG_VERSION_MANUFACTURER_URL="www.imgtec.com"
 CONFIG_VERSION_PRODUCT="Creator Ci40(Marduk)"

--- a/target/linux/pistachio/creator-platform-default-cascoda.config
+++ b/target/linux/pistachio/creator-platform-default-cascoda.config
@@ -2,6 +2,7 @@ CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_ca8210=y
 CONFIG_IMAGEOPT=y
+CONFIG_LIBCURL_OPENSSL=y
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_NICK="Ci40"
 CONFIG_VERSION_REPO="http://downloads.creatordev.io/pistachio/marduk/packages"

--- a/target/linux/pistachio/creator-platform-default-cascoda.config
+++ b/target/linux/pistachio/creator-platform-default-cascoda.config
@@ -3,6 +3,7 @@ CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_ca8210=y
 CONFIG_IMAGEOPT=y
 CONFIG_LIBCURL_OPENSSL=y
+CONFIG_OPENSSL_WITH_EC=y
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_NICK="Ci40"
 CONFIG_VERSION_REPO="http://downloads.creatordev.io/pistachio/marduk/packages"

--- a/target/linux/pistachio/creator-platform-default.config
+++ b/target/linux/pistachio/creator-platform-default.config
@@ -2,21 +2,9 @@ CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
 CONFIG_IMAGEOPT=y
-CONFIG_LIBCURL_OPENSSL=y
-CONFIG_OPENSSL_WITH_EC=y
-CONFIG_PACKAGE_ca-certificates=y
-CONFIG_PACKAGE_curl=y
-CONFIG_PACKAGE_libcurl=y
-CONFIG_PACKAGE_libopenssl=y
-CONFIG_PACKAGE_libustream-openssl=y
-# CONFIG_PACKAGE_opkg is not set
-CONFIG_PACKAGE_opkg-smime=y
-# CONFIG_PACKAGE_usign is not set
-CONFIG_PACKAGE_zlib=y
-# CONFIG_SIGNED_PACKAGES is not set
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_NICK="Ci40"
-CONFIG_VERSION_REPO="https://downloads.creatordev.io/pistachio/marduk/packages"
+CONFIG_VERSION_REPO="http://downloads.creatordev.io/pistachio/marduk/packages"
 CONFIG_VERSION_MANUFACTURER="Imagination Technologies"
 CONFIG_VERSION_MANUFACTURER_URL="www.imgtec.com"
 CONFIG_VERSION_PRODUCT="Creator Ci40(Marduk)"

--- a/target/linux/pistachio/creator-platform-default.config
+++ b/target/linux/pistachio/creator-platform-default.config
@@ -3,6 +3,7 @@ CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
 CONFIG_IMAGEOPT=y
 CONFIG_LIBCURL_OPENSSL=y
+CONFIG_OPENSSL_WITH_EC=y
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_NICK="Ci40"
 CONFIG_VERSION_REPO="http://downloads.creatordev.io/pistachio/marduk/packages"

--- a/target/linux/pistachio/creator-platform-default.config
+++ b/target/linux/pistachio/creator-platform-default.config
@@ -2,6 +2,7 @@ CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
 CONFIG_IMAGEOPT=y
+CONFIG_LIBCURL_OPENSSL=y
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_NICK="Ci40"
 CONFIG_VERSION_REPO="http://downloads.creatordev.io/pistachio/marduk/packages"

--- a/target/linux/pistachio/marduk/target.mk
+++ b/target/linux/pistachio/marduk/target.mk
@@ -12,7 +12,8 @@ DEFAULT_PACKAGES+=kmod-leds-gpio kmod-ledtrig-heartbeat kmod-i2c-core i2c-tools 
                   kmod-uccp420wlan fping iw hostapd wpa-cli wpa-supplicant \
                   kmod-tpm-i2c-infineon kmod-random-tpm tpm-tools \
                   uhttpd uboot-envtools tcpdump board-test proddata \
-                  luci kmod-bluetooth kmod-mac802154
+                  luci kmod-bluetooth kmod-mac802154 \
+                  curl libopenssl ca-certificates
 
 define Target/Description
         Marduk


### PR DESCRIPTION
Signed-off-by: Abhijit Mahajani <Abhijit.Mahajani@imgtec.com>
This connects #18, connects #91  
This includes multiple improvements:
1. Removes opkg-smime and related packages from creator-platform-default configs. Since we do not use https anymore for downloads url, we do not need libustream-openssl which was need by wget with ssl support.
2. Reverted the workaround of opkg -> opkg-smime from DEFAULT_PACKAGES.
3. Enabled curl, libopenssl, ca-certificates in pistachio/marduk/target.mk
4. Added CONFIG_LIBCURL_OPENSSL in creator-platform-default configs to use openssl instead of default polarssl for curl.
5. Added CONFIG_OPENSSL_WITH_EC in creator-platform-default configs for enabling the elliptic curve support in openssl.
6.Allowed BUILD_KEY to be passed from make arguments so that package signing can be done with constant public/private key pair, instead of generating a new one each build.