### PR TITLE
Add missing uci entry in uci config file system

### DIFF
--- a/target/linux/pistachio/base-files/etc/config/system
+++ b/target/linux/pistachio/base-files/etc/config/system
@@ -1,6 +1,7 @@
 config system
 	option hostname	OpenWrt
 	option timezone	UTC
+	option ttylogin	0
 
 config timeserver ntp
 	list server	0.openwrt.pool.ntp.org


### PR DESCRIPTION
This patch solves the problem of "uci: Entry not found" when console is actived.