### PR TITLE
pistachio: set cpu type to mips32r2

### DIFF
--- a/target/linux/pistachio/Makefile
+++ b/target/linux/pistachio/Makefile
@@ -15,6 +15,8 @@ SUBTARGETS=marduk
 
 KERNEL_PATCHVER:=4.4
 
+CPU_TYPE:=mips32r2
+
 include $(INCLUDE_DIR)/target.mk
 
 define Target/Description


### PR DESCRIPTION
Signed-off-by: Abhilash Tuse <Abhilash.Tuse@imgtec.com>
fixes #155