### PR TITLE
Jenkinsfile: don't add the creator feed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,6 @@
 def customFeeds = [
     ['packages', 'packages', 'https://github.com/CreatorDev'],
     ['ci40', 'ci40-platform-feed', 'https://github.com/CreatorDev'],
-    ['creator', 'creator-feed', 'https://github.com/CreatorDev'],
 ]
 def feedParams = []
 for (feed in customFeeds) {


### PR DESCRIPTION
We have decided to de-couple platform support and creator in terms
of release cycles therefore we don't want to add it to our builds
anymore.

Connects #187 