### PR TITLE
pistachio/image: Use hardcoded name for dts

### DIFF
--- a/target/linux/pistachio/image/Makefile
+++ b/target/linux/pistachio/image/Makefile
@@ -33,7 +33,7 @@ DEVICE_VARS += DEVICE_DTS_DIR DEVICE_DTS KERNEL_IN_UBI
 
 define Device/marduk_ca8210
 	PROFILES := marduk_ca8210
-	DEVICE_DTS := pistachio/pistachio_$(PROFILE)
+	DEVICE_DTS := pistachio/pistachio_marduk_ca8210
 	BLOCKSIZE := 256KiB
 	PAGESIZE := 4KiB
 endef
@@ -41,7 +41,7 @@ TARGET_DEVICES += marduk_ca8210
 
 define Device/marduk_cc2520
 	PROFILES := marduk_cc2520
-	DEVICE_DTS := pistachio/pistachio_$(PROFILE)
+	DEVICE_DTS := pistachio/pistachio_marduk_cc2520
 	BLOCKSIZE := 256KiB
 	PAGESIZE := 4KiB
 endef


### PR DESCRIPTION
So that custom profile which does not match board type can
be added easily.

Connects to #216 