### PR TITLE
Jenkinsfile: fix incorrect index in feeds override

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,7 +138,7 @@ node('docker && imgtec') {  // Only run on internal slaves as build takes a lot 
             sh 'cp feeds.conf.default feeds.conf'
             for (feed in customFeeds) {
                 if (params."OVERRIDE_${feed[0].toUpperCase()}"?.trim()){
-                    dir("feed-${feed[0]}") {
+                    dir("feed-${feed[1]}") {
                         checkout([
                             $class: 'GitSCM',
                             branches: [[name: env."OVERRIDE_${feed[0].toUpperCase()}"]],


### PR DESCRIPTION
This connects to #129 

${feeds[0]} => ci40
${feeds[1]} => ci40-platform-feed

Before this fix, dir("feed-${feed[0]}") => feed-ci40
which made, src-link ${feed[0]} ../feed-${feed[1]} => src-link ci40 ../feed-ci40-platform-feed

After this fix, dir("feed-${feed[1]}") => feed-ci40-platform-feed

Signed-off-by: Nikhil Zinjurde <nikhil.zinjurde@imgtec.com>