### PR TITLE
Backporting crypto:img-hash and sc16is7xx driver fixes into 4.4

### DIFF
--- a/target/linux/pistachio/patches-4.4/0001-crypto-img-hash-Fix-null-pointer-exception.patch
+++ b/target/linux/pistachio/patches-4.4/0001-crypto-img-hash-Fix-null-pointer-exception.patch
@@ -1,0 +1,30 @@
+From baf35fa134e9b545f540e7d2d36e24c8d4d5f5fb Mon Sep 17 00:00:00 2001
+From: Will Thomas <will.thomas@imgtec.com>
+Date: Fri, 5 Aug 2016 14:00:14 +0100
+Subject: crypto: img-hash - Fix null pointer exception
+
+Sporadic null pointer exceptions came from here. Fix them.
+
+Signed-off-by: Will Thomas <will.thomas@imgtec.com>
+Reviewed-by: James Hartley <james.hartley@imgtec.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ drivers/crypto/img-hash.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/crypto/img-hash.c b/drivers/crypto/img-hash.c
+index 68e8aa9..e5c941b 100644
+--- a/drivers/crypto/img-hash.c
++++ b/drivers/crypto/img-hash.c
+@@ -361,7 +361,7 @@ static void img_hash_dma_task(unsigned long d)
+ 	size_t nbytes, bleft, wsend, len, tbc;
+ 	struct scatterlist tsg;
+ 
+-	if (!ctx->sg)
++	if (!hdev->req || !ctx->sg)
+ 		return;
+ 
+ 	addr = sg_virt(ctx->sg);
+-- 
+2.6.2
+

--- a/target/linux/pistachio/patches-4.4/0002-crypto-img-hash-Fix-hash-request-context.patch
+++ b/target/linux/pistachio/patches-4.4/0002-crypto-img-hash-Fix-hash-request-context.patch
@@ -1,0 +1,36 @@
+From e55a5312be83ffef275ca15d729629aef5ea475c Mon Sep 17 00:00:00 2001
+From: Will Thomas <will.thomas@imgtec.com>
+Date: Fri, 5 Aug 2016 14:00:15 +0100
+Subject: crypto: img-hash - Fix hash request context
+
+Move 0 length buffer to end of structure to stop overwriting
+fallback request data. This doesn't cause a bug itself as the
+buffer is never used alongside the fallback but should be
+changed.
+
+Signed-off-by: Will Thomas <will.thomas@imgtec.com>
+Reviewed-by: James Hartley <james.hartley@imgtec.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ drivers/crypto/img-hash.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/crypto/img-hash.c b/drivers/crypto/img-hash.c
+index e5c941b..de2b86e 100644
+--- a/drivers/crypto/img-hash.c
++++ b/drivers/crypto/img-hash.c
+@@ -102,8 +102,10 @@ struct img_hash_request_ctx {
+ 	unsigned long		op;
+ 
+ 	size_t			bufcnt;
+-	u8 buffer[0] __aligned(sizeof(u32));
+ 	struct ahash_request	fallback_req;
++
++	/* Zero length buffer must remain last member of struct */
++	u8 buffer[0] __aligned(sizeof(u32));
+ };
+ 
+ struct img_hash_ctx {
+-- 
+2.6.2
+

--- a/target/linux/pistachio/patches-4.4/0003-crypto-img-hash-Reconfigure-DMA-Burst-length.patch
+++ b/target/linux/pistachio/patches-4.4/0003-crypto-img-hash-Reconfigure-DMA-Burst-length.patch
@@ -1,0 +1,40 @@
+From f49da2d303eb04b8099435f894b5411056e0e73e Mon Sep 17 00:00:00 2001
+From: Will Thomas <will.thomas@imgtec.com>
+Date: Fri, 5 Aug 2016 14:00:16 +0100
+Subject: crypto: img-hash - Reconfigure DMA Burst length
+
+Burst length of 16 drives the hash accelerator out of spec
+and causes stability issues in some cases. Reduce this to
+stop data being lost.
+
+Signed-off-by: Will Thomas <will.thomas@imgtec.com>
+Reviewed-by: James Hartley <james.hartley@imgtec.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ drivers/crypto/img-hash.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/crypto/img-hash.c b/drivers/crypto/img-hash.c
+index de2b86e..f8abbe3 100644
+--- a/drivers/crypto/img-hash.c
++++ b/drivers/crypto/img-hash.c
+@@ -71,6 +71,7 @@
+ #define DRIVER_FLAGS_MD5		BIT(21)
+ 
+ #define IMG_HASH_QUEUE_LENGTH		20
++#define IMG_HASH_DMA_BURST		4
+ #define IMG_HASH_DMA_THRESHOLD		64
+ 
+ #ifdef __LITTLE_ENDIAN
+@@ -342,7 +343,7 @@ static int img_hash_dma_init(struct img_hash_dev *hdev)
+ 	dma_conf.direction = DMA_MEM_TO_DEV;
+ 	dma_conf.dst_addr = hdev->bus_addr;
+ 	dma_conf.dst_addr_width = DMA_SLAVE_BUSWIDTH_4_BYTES;
+-	dma_conf.dst_maxburst = 16;
++	dma_conf.dst_maxburst = IMG_HASH_DMA_BURST;
+ 	dma_conf.device_fc = false;
+ 
+ 	err = dmaengine_slave_config(hdev->dma_lch,  &dma_conf);
+-- 
+2.6.2
+

--- a/target/linux/pistachio/patches-4.4/0004-crypto-img-hash-Add-suspend-resume-hooks-for-img-has.patch
+++ b/target/linux/pistachio/patches-4.4/0004-crypto-img-hash-Add-suspend-resume-hooks-for-img-has.patch
@@ -1,0 +1,64 @@
+From ac00a7d7dba2374eb42c1fa995b8a296da3b7896 Mon Sep 17 00:00:00 2001
+From: Govindraj Raja <Govindraj.Raja@imgtec.com>
+Date: Fri, 5 Aug 2016 14:00:17 +0100
+Subject: crypto: img-hash - Add suspend resume hooks for img hash
+
+Current img hash claims sys and periph gate clocks
+and this can be gated in system suspend scenarios.
+
+Add support for Device pm ops for img hash to gate
+the clocks claimed by img hash.
+
+Signed-off-by: Govindraj Raja <Govindraj.Raja@imgtec.com>
+Reviewed-by: Will Thomas <will.thomas@imgtec.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ drivers/crypto/img-hash.c | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/drivers/crypto/img-hash.c b/drivers/crypto/img-hash.c
+index f8abbe3..2622c01 100644
+--- a/drivers/crypto/img-hash.c
++++ b/drivers/crypto/img-hash.c
+@@ -1016,11 +1016,38 @@ static int img_hash_remove(struct platform_device *pdev)
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_PM_SLEEP
++static int img_hash_suspend(struct device *dev)
++{
++	struct img_hash_dev *hdev = dev_get_drvdata(dev);
++
++	clk_disable_unprepare(hdev->hash_clk);
++	clk_disable_unprepare(hdev->sys_clk);
++
++	return 0;
++}
++
++static int img_hash_resume(struct device *dev)
++{
++	struct img_hash_dev *hdev = dev_get_drvdata(dev);
++
++	clk_prepare_enable(hdev->hash_clk);
++	clk_prepare_enable(hdev->sys_clk);
++
++	return 0;
++}
++#endif /* CONFIG_PM_SLEEP */
++
++static const struct dev_pm_ops img_hash_pm_ops = {
++	SET_SYSTEM_SLEEP_PM_OPS(img_hash_suspend, img_hash_resume)
++};
++
+ static struct platform_driver img_hash_driver = {
+ 	.probe		= img_hash_probe,
+ 	.remove		= img_hash_remove,
+ 	.driver		= {
+ 		.name	= "img-hash-accelerator",
++		.pm	= &img_hash_pm_ops,
+ 		.of_match_table	= of_match_ptr(img_hash_match),
+ 	}
+ };
+-- 
+2.6.2
+

--- a/target/linux/pistachio/patches-4.4/0005-crypto-img-hash-Add-support-for-export-and-import.patch
+++ b/target/linux/pistachio/patches-4.4/0005-crypto-img-hash-Add-support-for-export-and-import.patch
@@ -1,0 +1,185 @@
+From 59eb90adf34a0825c4d13feb7bd6bdeef247847c Mon Sep 17 00:00:00 2001
+From: James Hartley <james.hartley@imgtec.com>
+Date: Fri, 5 Aug 2016 14:00:18 +0100
+Subject: crypto: img-hash - Add support for export and import
+
+Currently the img-hash accelerator does not probe
+successfully due to a change in the checks made during
+registration with the crypto framework. This is due to
+import and export functions not being defined. Correct
+this.
+
+Signed-off-by: James Hartley <james.hartley@imgtec.com>
+Signed-off-by: Will Thomas <will.thomas@imgtec.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ drivers/crypto/img-hash.c | 69 ++++++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 63 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/crypto/img-hash.c b/drivers/crypto/img-hash.c
+index 2622c01..fd4cd51 100644
+--- a/drivers/crypto/img-hash.c
++++ b/drivers/crypto/img-hash.c
+@@ -590,6 +590,32 @@ static int img_hash_finup(struct ahash_request *req)
+ 	return crypto_ahash_finup(&rctx->fallback_req);
+ }
+ 
++static int img_hash_import(struct ahash_request *req, const void *in)
++{
++	struct img_hash_request_ctx *rctx = ahash_request_ctx(req);
++	struct crypto_ahash *tfm = crypto_ahash_reqtfm(req);
++	struct img_hash_ctx *ctx = crypto_ahash_ctx(tfm);
++
++	ahash_request_set_tfm(&rctx->fallback_req, ctx->fallback);
++	rctx->fallback_req.base.flags = req->base.flags
++		& CRYPTO_TFM_REQ_MAY_SLEEP;
++
++	return crypto_ahash_import(&rctx->fallback_req, in);
++}
++
++static int img_hash_export(struct ahash_request *req, void *out)
++{
++	struct img_hash_request_ctx *rctx = ahash_request_ctx(req);
++	struct crypto_ahash *tfm = crypto_ahash_reqtfm(req);
++	struct img_hash_ctx *ctx = crypto_ahash_ctx(tfm);
++
++	ahash_request_set_tfm(&rctx->fallback_req, ctx->fallback);
++	rctx->fallback_req.base.flags = req->base.flags
++		& CRYPTO_TFM_REQ_MAY_SLEEP;
++
++	return crypto_ahash_export(&rctx->fallback_req, out);
++}
++
+ static int img_hash_digest(struct ahash_request *req)
+ {
+ 	struct crypto_ahash *tfm = crypto_ahash_reqtfm(req);
+@@ -646,10 +672,9 @@ static int img_hash_digest(struct ahash_request *req)
+ 	return err;
+ }
+ 
+-static int img_hash_cra_init(struct crypto_tfm *tfm)
++static int img_hash_cra_init(struct crypto_tfm *tfm, const char *alg_name)
+ {
+ 	struct img_hash_ctx *ctx = crypto_tfm_ctx(tfm);
+-	const char *alg_name = crypto_tfm_alg_name(tfm);
+ 	int err = -ENOMEM;
+ 
+ 	ctx->fallback = crypto_alloc_ahash(alg_name, 0,
+@@ -669,6 +694,26 @@ err:
+ 	return err;
+ }
+ 
++static int img_hash_cra_md5_init(struct crypto_tfm *tfm)
++{
++	return img_hash_cra_init(tfm, "md5-generic");
++}
++
++static int img_hash_cra_sha1_init(struct crypto_tfm *tfm)
++{
++	return img_hash_cra_init(tfm, "sha1-generic");
++}
++
++static int img_hash_cra_sha224_init(struct crypto_tfm *tfm)
++{
++	return img_hash_cra_init(tfm, "sha224-generic");
++}
++
++static int img_hash_cra_sha256_init(struct crypto_tfm *tfm)
++{
++	return img_hash_cra_init(tfm, "sha256-generic");
++}
++
+ static void img_hash_cra_exit(struct crypto_tfm *tfm)
+ {
+ 	struct img_hash_ctx *tctx = crypto_tfm_ctx(tfm);
+@@ -714,9 +759,12 @@ static struct ahash_alg img_algs[] = {
+ 		.update = img_hash_update,
+ 		.final = img_hash_final,
+ 		.finup = img_hash_finup,
++		.export = img_hash_export,
++		.import = img_hash_import,
+ 		.digest = img_hash_digest,
+ 		.halg = {
+ 			.digestsize = MD5_DIGEST_SIZE,
++			.statesize = sizeof(struct md5_state),
+ 			.base = {
+ 				.cra_name = "md5",
+ 				.cra_driver_name = "img-md5",
+@@ -726,7 +774,7 @@ static struct ahash_alg img_algs[] = {
+ 				CRYPTO_ALG_NEED_FALLBACK,
+ 				.cra_blocksize = MD5_HMAC_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct img_hash_ctx),
+-				.cra_init = img_hash_cra_init,
++				.cra_init = img_hash_cra_md5_init,
+ 				.cra_exit = img_hash_cra_exit,
+ 				.cra_module = THIS_MODULE,
+ 			}
+@@ -737,9 +785,12 @@ static struct ahash_alg img_algs[] = {
+ 		.update = img_hash_update,
+ 		.final = img_hash_final,
+ 		.finup = img_hash_finup,
++		.export = img_hash_export,
++		.import = img_hash_import,
+ 		.digest = img_hash_digest,
+ 		.halg = {
+ 			.digestsize = SHA1_DIGEST_SIZE,
++			.statesize = sizeof(struct sha1_state),
+ 			.base = {
+ 				.cra_name = "sha1",
+ 				.cra_driver_name = "img-sha1",
+@@ -749,7 +800,7 @@ static struct ahash_alg img_algs[] = {
+ 				CRYPTO_ALG_NEED_FALLBACK,
+ 				.cra_blocksize = SHA1_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct img_hash_ctx),
+-				.cra_init = img_hash_cra_init,
++				.cra_init = img_hash_cra_sha1_init,
+ 				.cra_exit = img_hash_cra_exit,
+ 				.cra_module = THIS_MODULE,
+ 			}
+@@ -760,9 +811,12 @@ static struct ahash_alg img_algs[] = {
+ 		.update = img_hash_update,
+ 		.final = img_hash_final,
+ 		.finup = img_hash_finup,
++		.export = img_hash_export,
++		.import = img_hash_import,
+ 		.digest = img_hash_digest,
+ 		.halg = {
+ 			.digestsize = SHA224_DIGEST_SIZE,
++			.statesize = sizeof(struct sha256_state),
+ 			.base = {
+ 				.cra_name = "sha224",
+ 				.cra_driver_name = "img-sha224",
+@@ -772,7 +826,7 @@ static struct ahash_alg img_algs[] = {
+ 				CRYPTO_ALG_NEED_FALLBACK,
+ 				.cra_blocksize = SHA224_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct img_hash_ctx),
+-				.cra_init = img_hash_cra_init,
++				.cra_init = img_hash_cra_sha224_init,
+ 				.cra_exit = img_hash_cra_exit,
+ 				.cra_module = THIS_MODULE,
+ 			}
+@@ -783,9 +837,12 @@ static struct ahash_alg img_algs[] = {
+ 		.update = img_hash_update,
+ 		.final = img_hash_final,
+ 		.finup = img_hash_finup,
++		.export = img_hash_export,
++		.import = img_hash_import,
+ 		.digest = img_hash_digest,
+ 		.halg = {
+ 			.digestsize = SHA256_DIGEST_SIZE,
++			.statesize = sizeof(struct sha256_state),
+ 			.base = {
+ 				.cra_name = "sha256",
+ 				.cra_driver_name = "img-sha256",
+@@ -795,7 +852,7 @@ static struct ahash_alg img_algs[] = {
+ 				CRYPTO_ALG_NEED_FALLBACK,
+ 				.cra_blocksize = SHA256_BLOCK_SIZE,
+ 				.cra_ctxsize = sizeof(struct img_hash_ctx),
+-				.cra_init = img_hash_cra_init,
++				.cra_init = img_hash_cra_sha256_init,
+ 				.cra_exit = img_hash_cra_exit,
+ 				.cra_module = THIS_MODULE,
+ 			}
+-- 
+2.6.2
+

--- a/target/linux/pistachio/patches-4.4/0006-crypto-img-hash-log-a-successful-probe.patch
+++ b/target/linux/pistachio/patches-4.4/0006-crypto-img-hash-log-a-successful-probe.patch
@@ -1,0 +1,32 @@
+From 2b1fb41357fea6ba83a23489606f663a96b2bf01 Mon Sep 17 00:00:00 2001
+From: James Hartley <james.hartley@imgtec.com>
+Date: Fri, 5 Aug 2016 14:00:19 +0100
+Subject: crypto: img-hash - log a successful probe
+
+Currently the probe function only emits an output on success
+when debug is specifically enabled. It would be more useful
+if this happens by default.
+
+Signed-off-by: James Hartley <james.hartley@imgtec.com>
+Reviewed-by: Will Thomas <will.thomas@imgtec.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ drivers/crypto/img-hash.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/crypto/img-hash.c b/drivers/crypto/img-hash.c
+index fd4cd51..60410d7 100644
+--- a/drivers/crypto/img-hash.c
++++ b/drivers/crypto/img-hash.c
+@@ -1031,7 +1031,7 @@ static int img_hash_probe(struct platform_device *pdev)
+ 	err = img_register_algs(hdev);
+ 	if (err)
+ 		goto err_algs;
+-	dev_dbg(dev, "Img MD5/SHA1/SHA224/SHA256 Hardware accelerator initialized\n");
++	dev_info(dev, "Img MD5/SHA1/SHA224/SHA256 Hardware accelerator initialized\n");
+ 
+ 	return 0;
+ 
+-- 
+2.6.2
+

--- a/target/linux/pistachio/patches-4.4/0007-crypto-img-hash-Fix-set_reqsize-call.patch
+++ b/target/linux/pistachio/patches-4.4/0007-crypto-img-hash-Fix-set_reqsize-call.patch
@@ -1,0 +1,28 @@
+From 19bdbda4cd027cbc421728d520efc8de579aa2b8 Mon Sep 17 00:00:00 2001
+From: Will Thomas <will.thomas@imgtec.com>
+Date: Fri, 5 Aug 2016 14:00:20 +0100
+Subject: crypto: img-hash - Fix set_reqsize call
+
+Properly allocate enough memory to respect the fallback.
+
+Signed-off-by: Will Thomas <will.thomas@imgtec.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ drivers/crypto/img-hash.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/crypto/img-hash.c b/drivers/crypto/img-hash.c
+index 60410d7..a2e77b8 100644
+--- a/drivers/crypto/img-hash.c
++++ b/drivers/crypto/img-hash.c
+@@ -686,6 +686,7 @@ static int img_hash_cra_init(struct crypto_tfm *tfm, const char *alg_name)
+ 	}
+ 	crypto_ahash_set_reqsize(__crypto_ahash_cast(tfm),
+ 				 sizeof(struct img_hash_request_ctx) +
++				 crypto_ahash_reqsize(ctx->fallback) +
+ 				 IMG_HASH_DMA_THRESHOLD);
+ 
+ 	return 0;
+-- 
+2.6.2
+

--- a/target/linux/pistachio/patches-4.4/0008-sc16is7xx-always-write-state-when-configuring-GPIO-a.patch
+++ b/target/linux/pistachio/patches-4.4/0008-sc16is7xx-always-write-state-when-configuring-GPIO-a.patch
@@ -1,0 +1,39 @@
+From 5bc99d258eee2d9028f07364b9f4d1788d61a70f Mon Sep 17 00:00:00 2001
+From: Francois Berder <Francois.Berder@imgtec.com>
+Date: Tue, 25 Oct 2016 13:24:13 +0100
+Subject: sc16is7xx: always write state when configuring GPIO as an output
+
+The regmap_update first reads the IOState register and then triggers
+a write if needed. However, GPIOS might be configured as an input so
+ the read to IOState on this GPIO is the current state which might
+be random.
+
+Signed-off-by: Francois Berder <Francois.Berder@imgtec.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/tty/serial/sc16is7xx.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/tty/serial/sc16is7xx.c b/drivers/tty/serial/sc16is7xx.c
+index edb5305..7f9f968 100644
+--- a/drivers/tty/serial/sc16is7xx.c
++++ b/drivers/tty/serial/sc16is7xx.c
+@@ -1120,9 +1120,13 @@ static int sc16is7xx_gpio_direction_output(struct gpio_chip *chip,
+ 	struct sc16is7xx_port *s = container_of(chip, struct sc16is7xx_port,
+ 						gpio);
+ 	struct uart_port *port = &s->p[0].port;
++	u8 state = sc16is7xx_port_read(port, SC16IS7XX_IOSTATE_REG);
+ 
+-	sc16is7xx_port_update(port, SC16IS7XX_IOSTATE_REG, BIT(offset),
+-			      val ? BIT(offset) : 0);
++	if (val)
++		state |= BIT(offset);
++	else
++		state &= ~BIT(offset);
++	sc16is7xx_port_write(port, SC16IS7XX_IOSTATE_REG, state);
+ 	sc16is7xx_port_update(port, SC16IS7XX_IODIR_REG, BIT(offset),
+ 			      BIT(offset));
+ 
+-- 
+2.6.2
+


### PR DESCRIPTION
pistachio/patches-4.4: backport sc16is7xx patch into 4.4
This fixes #253 

pistachio/patches-4.4: backport crypto: img-hash driver to 4.4
This fixes #261 