### PR TITLE
Resolve the race condition between the Bluetooth hci driver and the B…

### DIFF
--- a/target/linux/pistachio/base-files/etc/init.d/bt-config
+++ b/target/linux/pistachio/base-files/etc/init.d/bt-config
@@ -1,0 +1,53 @@
+#!/bin/sh /etc/rc.common
+#
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+START=85
+STOP=85
+
+config_bluetooth() {
+	. /lib/functions/mac.sh
+	. /lib/functions/utils.sh
+
+	local IS_BT_RUNNING
+	local timeout=5
+	local time=$(awk -F "." '{print $1}' /proc/uptime | awk '{print $1}')
+	local elap_time=0
+
+	while [ -z "$IS_BT_RUNNING" ]
+	do
+		if [ $elap_time -lt $timeout ]
+		then
+			elap_time=$(elapsed_time $time)
+		else
+			logger " waiting for bluetoothd daemon: bt-config timed out "
+			return 1
+		fi 
+		IS_BT_RUNNING=$(pgrep bluetoothd)
+	done
+	# give some time for the bluetoothd to come up before applying 
+	# configuration
+	sleep 3
+	local MAC=$(get_bluetooth_mac)
+	local BT_ADDR_MASK=10
+	local BT_ADDR=$(echo $MAC | cut -c $BT_ADDR_MASK-)
+	local BT_NAME=Creator-Ci40["$BT_ADDR"]
+	hciconfig hci0 reset &&
+	hciconfig hci0 up &&
+	hciconfig hci0 piscan &&
+	hciconfig hci0 version &&
+	hciconfig hci0 name $BT_NAME || (logger "hciconfig failed" && return 1)
+	hcitool dev	
+}
+
+start(){
+	config_bluetooth
+}
+
+stop(){
+	hciconfig hci0 down
+}

--- a/target/linux/pistachio/base-files/etc/init.d/bt-csr
+++ b/target/linux/pistachio/base-files/etc/init.d/bt-csr
@@ -139,22 +139,28 @@ EOF
 		}
 
 	fi
-
-# Configure HCI and get some version info
-	BT_ADDR_MASK=10
-	hciconfig hci0 reset &&\
-	hciconfig hci0 up &&\
-	hciconfig hci0 piscan &&\
-	hciconfig hci0 version &&\
-	BT_ADDR=$(echo $MAC | cut -c $BT_ADDR_MASK-) &&\
-	BT_NAME="Creator-Ci40["$BT_ADDR"]" &&\
-	hciconfig hci0 name $BT_NAME &&\
-	hcitool dev || (echo  "Failed to configure" && exit 1)
-
 }
 
+
 start() {
+	. /lib/functions/utils.sh
+
 	echo  "Starting Bluetooth..."
+	local timeout=5
+	local time=$(awk -F "." '{print $1}' /proc/uptime | awk '{print $1}')
+	local elap_time=0
+
+	while ! lsmod | grep -q hci_uart
+	do
+		if [ $elap_time -lt $timeout ]
+		then
+			elap_time=$(elapsed_time $time)
+		else
+			logger " waiting for hci_uart module: bt-csr timed out "
+			return 1
+		fi
+	done
+	sleep 2
 	reset_csr && sleep 1 && n_reset_csr && bringup_csr& 
 }
 

--- a/target/linux/pistachio/base-files/lib/functions/utils.sh
+++ b/target/linux/pistachio/base-files/lib/functions/utils.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+
+elapsed_time() {
+	local time=$1
+	current_time=$(awk -F "." '{print $1}' /proc/uptime | awk '{print $1}')
+	local time_elapsed=0
+	time_elapsed=$(expr $current_time - $time)
+	echo "$time_elapsed"
+}


### PR DESCRIPTION
…T init scripts

The BT initialization scripts interrupts the BT driver from enumerating the BT controller
ensure the proper sequence is executed, driver loading, BT controller init, Bluetoothd daemon run, BT configuration

connects CreatorDev/openwrt#256 