### PR TITLE
Add missing second ifname in proto_lowpan_teardown()

### DIFF
--- a/package/network/utils/wpan-tools/files/lowpan.sh
+++ b/package/network/utils/wpan-tools/files/lowpan.sh
@@ -47,7 +47,7 @@ proto_lowpan_teardown() {
 	local iface="$2"
 
 	local ifname
-	json_get_var ifname
+	json_get_var ifname ifname
 
 	local id=${ifname##*[[:alpha:]]}
 	local interface="$cfg$id" # i.e wpan0


### PR DESCRIPTION
json_get_var needs two parameters.

Signed-off-by: Xue Liu <liuxuenetmail@gmail.com>