### PR TITLE
pistachio: set DEVICE_REVISION to v7+

### DIFF
--- a/target/linux/pistachio/marduk-default.config
+++ b/target/linux/pistachio/marduk-default.config
@@ -9,3 +9,4 @@ CONFIG_VERSION_REPO="http://downloads.creatordev.io/openwrt/latest/pistachio/mar
 CONFIG_VERSION_MANUFACTURER="Imagination Technologies"
 CONFIG_VERSION_MANUFACTURER_URL="www.imgtec.com"
 CONFIG_VERSION_PRODUCT="Creator Ci40(marduk)"
+CONFIG_VERSION_HWREV="v7+"


### PR DESCRIPTION
This represents all the h/w versions of Ci40 boards available publicly v7 onwards that will work with the default configuration of marduk platform

The version is not set for marduk_legacy boards as they are no longer in use and hence not supported

This closes #293 

Signed-off-by: Nikhil Zinjurde <nikhil.zinjurde@imgtec.com>