### PR TITLE
hostapd: fix reload frequency change patch

### DIFF
--- a/package/network/services/hostapd/patches/340-reload_freq_change.patch
+++ b/package/network/services/hostapd/patches/340-reload_freq_change.patch
@@ -1,6 +1,6 @@
 --- a/src/ap/hostapd.c
 +++ b/src/ap/hostapd.c
-@@ -80,6 +80,16 @@ static void hostapd_reload_bss(struct ho
+@@ -80,6 +80,25 @@ static void hostapd_reload_bss(struct ho
  #endif /* CONFIG_NO_RADIUS */
  
  	ssid = &hapd->conf->ssid;
@@ -14,13 +14,38 @@
 +			 hapd->iconf->vht_oper_centr_freq_seg0_idx,
 +			 hapd->iconf->vht_oper_centr_freq_seg1_idx);
 +
++	if (hapd->iface->current_mode) {
++		if (hostapd_prepare_rates(hapd->iface, hapd->iface->current_mode)) {
++			wpa_printf(MSG_ERROR, "Failed to prepare rates table.");
++			hostapd_logger(hapd, NULL, HOSTAPD_MODULE_IEEE80211,
++				       HOSTAPD_LEVEL_WARNING,
++				       "Failed to prepare rates table.");
++		}
++	}
++
  	if (!ssid->wpa_psk_set && ssid->wpa_psk && !ssid->wpa_psk->next &&
  	    ssid->wpa_passphrase_set && ssid->wpa_passphrase) {
  		/*
-@@ -179,21 +189,12 @@ int hostapd_reload_config(struct hostapd
+@@ -158,6 +177,7 @@ int hostapd_reload_config(struct hostapd
+ 	struct hostapd_data *hapd = iface->bss[0];
+ 	struct hostapd_config *newconf, *oldconf;
+ 	size_t j;
++	int i;
+ 
+ 	if (iface->config_fname == NULL) {
+ 		/* Only in-memory config in use - assume it has been updated */
+@@ -179,21 +199,20 @@ int hostapd_reload_config(struct hostapd
  	oldconf = hapd->iconf;
  	iface->conf = newconf;
  
++	for (i = 0; i < iface->num_hw_features; i++) {
++		struct hostapd_hw_modes *mode = &iface->hw_features[i];
++		if (mode->mode == iface->conf->hw_mode) {
++			iface->current_mode = mode;
++			break;
++		}
++	}
++
 +	if (iface->conf->channel)
 +		iface->freq = hostapd_hw_get_freq(hapd, iface->conf->channel);
 +


### PR DESCRIPTION
Without this change ap+sta does not work. It updates current_mode
structure based on configured hw_mode received from wpa_supplicant.
Also prepare rates table after frequency selection.

Signed-off-by: Abhilash Tuse <Abhilash.Tuse@imgtec.com>