### PR TITLE
Jenkinsfile: remove ci40 prefixing for release VERSION

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ node('docker && imgtec') {  // Only run on internal slaves as build takes a lot 
             // Package server config
             if (params.VERSION) {
                 echo 'Updating server location for package downloads'
-                sh "sed -i '/^CONFIG_VERSION_REPO/s/latest/ci40-${params.VERSION}/' .config"
+                sh "sed -i '/^CONFIG_VERSION_REPO/s/latest/${params.VERSION}/' .config"
             }
 
             // Add development config


### PR DESCRIPTION
In case of VERSION string contains branchname-version then ci40 was getting prefixed unnecessarily.
So removing the extra ci40 prefixing for release builds.

Signed-off-by: Abhijit Mahajani <Abhijit.Mahajani@imgtec.com>